### PR TITLE
Fix broken backport in ipv6 handling

### DIFF
--- a/0001-Fix-bad-ipv6-comparison.patch
+++ b/0001-Fix-bad-ipv6-comparison.patch
@@ -1,4 +1,4 @@
-From 8649988de31cd283c16753bc4005f478bef13270 Mon Sep 17 00:00:00 2001
+From 16aa295ae86791e7b773114102790af46bb7b7ce Mon Sep 17 00:00:00 2001
 From: Lon Hohberger <lon@metamorphism.com>
 Date: Fri, 27 Jul 2018 16:27:31 -0400
 Subject: [PATCH 1/3] Fix bad ipv6 comparison
@@ -6,6 +6,8 @@ Subject: [PATCH 1/3] Fix bad ipv6 comparison
 When performing DNS lookups, the source address from resolv.conf
 may have stray zeroes in it, or the address string returned from
 socket.recvfrom may. Purge them before comparing tuples.
+
+Original backport was broken.
 
 Resolves: rhbz#1607967
 
@@ -16,7 +18,7 @@ Signed-off-by: Lon Hohberger <lhh@redhat.com>
  1 file changed, 14 insertions(+), 1 deletion(-)
 
 diff --git a/eventlet/support/greendns.py b/eventlet/support/greendns.py
-index ea0924c..3ecbc9b 100644
+index ea0924c..412e018 100644
 --- a/eventlet/support/greendns.py
 +++ b/eventlet/support/greendns.py
 @@ -35,6 +35,7 @@
@@ -27,11 +29,11 @@ index ea0924c..3ecbc9b 100644
  from eventlet import patcher
  from eventlet.green import _socket_nodns
  from eventlet.green import os
-@@ -670,7 +671,12 @@ def udp(q, where, timeout=DNS_QUERY_TIMEOUT, port=53,
-         except:
-             af = dns.inet.AF_INET
-     if af == dns.inet.AF_INET:
--        destination = (where, port)
+@@ -674,7 +675,12 @@ def udp(q, where, timeout=DNS_QUERY_TIMEOUT, port=53,
+         if source is not None:
+             source = (source, source_port)
+     elif af == dns.inet.AF_INET6:
+-        destination = (where, port, 0, 0)
 +        # Purge any stray zeroes in source address.  When doing the tuple comparison
 +        # below, we need to always ensure both our target and where we receive replies
 +        # from are compared with all zeroes removed so that we don't erroneously fail.
@@ -39,8 +41,8 @@ index ea0924c..3ecbc9b 100644
 +        where_trunc = dns.ipv6.inet_ntoa(dns.ipv6.inet_aton(where))
 +        destination = (where_trunc, port, 0, 0)
          if source is not None:
-             source = (source, source_port)
-     elif af == dns.inet.AF_INET6:
+             source = (source, source_port, 0, 0)
+ 
 @@ -697,6 +703,13 @@ def udp(q, where, timeout=DNS_QUERY_TIMEOUT, port=53,
                  # Q: Do we also need to catch coro.CoroutineSocketWake and pass?
                  if expiration - time.time() <= 0.0:
@@ -56,5 +58,5 @@ index ea0924c..3ecbc9b 100644
                  break
              if not ignore_unexpected:
 -- 
-2.13.6
+2.17.1
 

--- a/python-eventlet.spec
+++ b/python-eventlet.spec
@@ -12,7 +12,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.20.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Highly concurrent networking library
 License:        MIT
 URL:            http://eventlet.net
@@ -180,7 +180,7 @@ rm -rf %{buildroot}/%{python2_sitelib}/%{pypi_name}/green/http/{cookiejar,client
 %endif
 
 %changelog
-* Wed Aug 08 2018 Lon Hohberger <lon@redhat.com> 0.20.1-4
+* Wed Aug 08 2018 Lon Hohberger <lon@redhat.com> 0.20.1-5
 - Fix ipv6 address handling (rhbz#1607967)
 
 * Mon Aug 06 2018 Daniel Alvarez <dalvarez@redhat.com> - 0.20.1-3


### PR DESCRIPTION
The original patch here was a backport, but had the logic
backwards when handling ipv4 vs ipv6.  This now matches
upstream.

Signed-off-by: Lon Hohberger <lon@metamorphism.com>